### PR TITLE
fix: put brew shellenv before tools that shell out to brew

### DIFF
--- a/ghostty/.config/ghostty/config
+++ b/ghostty/.config/ghostty/config
@@ -11,3 +11,4 @@ font-family = MesloLGSDZ Nerd Font Mono
 font-size = 16
 clipboard-read = allow
 clipboard-write = allow
+keybind = shift+enter=text:\x1b[13;2u

--- a/nvim/.config/nvim/lua/alex_untitled/keymaps.lua
+++ b/nvim/.config/nvim/lua/alex_untitled/keymaps.lua
@@ -16,14 +16,38 @@ vim.keymap.set({ "n" }, "<C-c>", "<cmd>cnext<CR>")
 vim.keymap.set({ "n" }, "<C-d>", "<cmd>cprev<CR>")
 vim.keymap.set({ "n" }, "<C-x>", "<cmd>cclose<cr>")
 vim.keymap.set({ "n" }, "<leader>v", "<cmd>vsplit<cr>")
--- vim.keymap.set({ "n" }, "<Tab>", "<cmd>BufferLineCycleNext<cr>")
--- vim.keymap.set({ "n" }, "<S-Tab>", "<cmd>BufferLineCyclePrev<cr>")
--- vim.keymap.set({ "n" }, "<leader>a", "<cmd>BufferLineTogglePin<cr>")
--- vim.keymap.set({ "n" }, "<leader>z", "<cmd>BufferLineGroupToggle ungrouped<cr>")
--- vim.keymap.set({ "n" }, "<leader>Z", "<cmd>BufferLineGroupClose ungrouped<cr>")
--- vim.keymap.set({ "n" }, "<leader>1", "<cmd>BufferLinePick<cr>")
--- vim.keymap.set({ "n" }, "<leader>w", "<cmd>CloseBufferSmartly<cr>")
--- vim.keymap.set({ "n" }, "<leader>W", "<cmd>BufferLineCloseOthers<cr>")
+-- Buffer cycling
+vim.keymap.set("n", "<Tab>", "<cmd>bnext<cr>")
+vim.keymap.set("n", "<S-Tab>", "<cmd>bprev<cr>")
+
+-- Harpoon
+local harpoon = require("harpoon")
+harpoon:setup()
+
+vim.keymap.set("n", "<leader>a", function() harpoon:list():add() end, { desc = "Harpoon add" })
+vim.keymap.set("n", "<leader>h", function() harpoon.ui:toggle_quick_menu(harpoon:list()) end, { desc = "Harpoon menu" })
+vim.keymap.set("n", "<leader>1", function() harpoon:list():select(1) end, { desc = "Harpoon 1" })
+vim.keymap.set("n", "<leader>2", function() harpoon:list():select(2) end, { desc = "Harpoon 2" })
+vim.keymap.set("n", "<leader>3", function() harpoon:list():select(3) end, { desc = "Harpoon 3" })
+vim.keymap.set("n", "<leader>4", function() harpoon:list():select(4) end, { desc = "Harpoon 4" })
+
+-- Close all buffers except harpooned ones
+vim.keymap.set("n", "<leader>Z", function()
+	local harpooned = {}
+	local list = harpoon:list()
+	for i = 1, list:length() do
+		local item = list:get(i)
+		if item then
+			harpooned[vim.fn.fnamemodify(item.value, ":p")] = true
+		end
+	end
+
+	for _, buf in ipairs(vim.fn.getbufinfo({ buflisted = 1 })) do
+		if not harpooned[buf.name] then
+			vim.api.nvim_buf_delete(buf.bufnr, { force = false })
+		end
+	end
+end, { desc = "Close non-harpooned buffers" })
 vim.keymap.set({ "n" }, "<leader>q", "<cmd>q<cr>", { silent = true })
 vim.keymap.set({ "n" }, "<leader>f", "<cmd>lua vim.lsp.buf.format()<cr>", { silent = true })
 
@@ -33,13 +57,15 @@ vim.keymap.set("n", "<leader>b", "<cmd>Gitsigns toggle_current_line_blame<cr>")
 local telescope_builtin = require("telescope.builtin")
 vim.keymap.set("n", "<leader>t", "<cmd>AboonFinder<cr>", {})
 vim.keymap.set("n", "<leader>d", function()
-	require("telescope").extensions.file_browser.file_browser()
+	require("telescope").extensions.file_browser.file_browser({ respect_gitignore = false })
 end)
 vim.keymap.set("n", "<leader>D", function()
-	require("telescope").extensions.file_browser.file_browser({ path = "%:p:h", select_buffer = true })
+	require("telescope").extensions.file_browser.file_browser({ path = "%:p:h", select_buffer = true, respect_gitignore = false })
 end)
 -- vim.keymap.set("n", "<leader>D", file_browser.file_browser, { path = "%:p:h", select_buffer = true })
-vim.keymap.set("n", "<leader>T", telescope_builtin.find_files, {})
+vim.keymap.set("n", "<leader>T", function()
+	telescope_builtin.find_files({ no_ignore = true })
+end, {})
 vim.keymap.set("n", "<leader>F", telescope_builtin.live_grep, {})
 vim.keymap.set("n", "fb", telescope_builtin.buffers, {})
 vim.keymap.set("n", "fh", telescope_builtin.help_tags, {})

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -3,7 +3,7 @@ bind r source-file ~/.tmux.conf
 # macOS hacky hack
 if-shell "type 'reattach-to-user-namespace' >/dev/null" "set -g default-command 'reattach-to-user-namespace -l $SHELL'"
 
-set -g default-terminal "screen-256color"
+set -g default-terminal "xterm-ghostty"
 set -g set-titles on
 set -g allow-rename off
 set -g mouse on
@@ -26,6 +26,8 @@ set -g window-status-current-format " #I: #W "
 setw -g mode-keys vi
 
 set -sg escape-time 0
+set -s extended-keys on
+set -as terminal-features 'xterm*:extkeys'
 
 unbind-key j
 bind-key j select-pane -D
@@ -44,3 +46,13 @@ unbind-key H
 bind-key -r H resize-pane -L
 unbind-key L
 bind-key -r L resize-pane -R
+
+# New panes/windows inherit the active pane's CWD instead of falling back
+# to the session launch dir (the macOS-tmux default).
+bind '"' split-window -c "#{pane_current_path}"
+bind '%' split-window -h -c "#{pane_current_path}"
+bind c new-window -c "#{pane_current_path}"
+
+# Cycle windows without prefix (parallels prefix h/l for panes).
+bind-key -n M-h previous-window
+bind-key -n M-l next-window

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -105,12 +105,20 @@ source $ZSH/oh-my-zsh.sh
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
-source $(brew --prefix asdf)/libexec/asdf.sh
+# Homebrew must be on PATH before anything below shells out to brew or
+# brew-installed tools (asdf, mise).
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+# asdf <0.16 ships a shell script; 0.16+ is a binary that only needs shims on PATH
+if [ -f "$(brew --prefix asdf)/libexec/asdf.sh" ]; then
+  source "$(brew --prefix asdf)/libexec/asdf.sh"
+else
+  export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+fi
 eval "$(mise activate zsh)"
 export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"
 
 # History settings live in the dotfiles repo (must load after oh-my-zsh,
 # which sets its own smaller HISTSIZE/SAVEHIST).
 source ~/dotfiles/zsh/.shell-includes/history.zsh
-eval "$(/opt/homebrew/bin/brew shellenv)"
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -3,6 +3,9 @@
 
 # Path to your Oh My Zsh installation.
 export ZSH="$HOME/.oh-my-zsh"
+source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+source ~/.shell-includes/prompt.zsh
+source ~/.shell-includes/aliases.zsh
 
 # Set name of the theme to load --- if set to "random", it will
 # load a random theme each time Oh My Zsh is loaded, in which case,
@@ -109,3 +112,5 @@ export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"
 # History settings live in the dotfiles repo (must load after oh-my-zsh,
 # which sets its own smaller HISTSIZE/SAVEHIST).
 source ~/dotfiles/zsh/.shell-includes/history.zsh
+eval "$(/opt/homebrew/bin/brew shellenv)"
+


### PR DESCRIPTION
## Summary
- New terminals errored with `command not found: brew` and `command not found: mise`.
- Root cause: `eval "$(/opt/homebrew/bin/brew shellenv)"` ran at the very bottom of `.zshrc`, after the asdf/mise blocks that shell out to `brew` and rely on `/opt/homebrew/bin` already being on `PATH`. A brand new terminal starts with a bare system PATH, so those earlier blocks failed.
- Moved the `brew shellenv` eval above the asdf/mise setup and removed the now-redundant copy at the bottom.

## Test plan
- [x] `env -i HOME="$HOME" USER="$USER" TERM=xterm-256color PATH="/usr/bin:/bin:/usr/sbin:/sbin" zsh -l -i -c 'command -v brew mise; mise --version'` — resolves cleanly with no errors, confirming brew/mise both come up in a from-scratch terminal.